### PR TITLE
Update .gitattributes for linux.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,4 +9,4 @@
 *.wri binary
 *.nrc binary
 *.NRC binary
-w/bin/* binary
+w/bin/**/* binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,7 @@
 *.h text
 *.dll binary
 *.DLL binary
+*.bmp binary
+*.hlp binary
+*.wri binary
+*.nrc binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,6 @@
 # Set the default behavior, in case people don't have core.autocrlf set.
 * text eol=crlf
-
-*.lod text eol=crlf
+*.c text
+*.h text
+*.dll binary
+*.DLL binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -8,4 +8,5 @@
 *.hlp binary
 *.wri binary
 *.nrc binary
+*.NRC binary
 w/bin/* binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -10,3 +10,5 @@
 *.nrc binary
 *.NRC binary
 w/bin/**/* binary
+w/libr/**/* binary
+w/libz/**/* binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -8,3 +8,4 @@
 *.hlp binary
 *.wri binary
 *.nrc binary
+w/bin/* binary


### PR DESCRIPTION
This is a change so that git on linux doesn't try to automatically add CR-LF to binary files.
