### PR TITLE
Fix bug that had PRIMARY KEY defined twice in postgres

### DIFF
--- a/a/oe/kzhsqlxb.c
+++ b/a/oe/kzhsqlxb.c
@@ -2828,7 +2828,7 @@ fnBuildColumn( zVIEW  vDTE, zLONG  f, zPCHAR pchLine )
          if ( pchKeyType[ 0 ] == 'D' )
 	 {
             // The key type is 'D' for data which means it's the main key.
-	    zsprintf( pchEnd, " SERIAL PRIMARY KEY " );
+	    zsprintf( pchEnd, " SERIAL " );
 	 }
 	 else
 	 {

--- a/a/oe/kzhsqlxb.c
+++ b/a/oe/kzhsqlxb.c
@@ -3578,12 +3578,6 @@ BuildDDL( zVIEW  vDTE,
          goto EndOfFunction;
    #endif
 
-#elif defined( POSTGRESQL ) 
-
-       zsprintf( szLine, "SET SCHEMA '%s' %s", pchDatabaseName, LINE_TERMINATOR );
-       if ( fnWriteLine( vDTE, f, szLine ) < 0 )
-         goto EndOfFunction;
-
 #endif
 
    GetAddrForAttribute( &pchDefaultOwner, vDTE, "TE_DBMS_Source",


### PR DESCRIPTION
I'm getting lines generated in the ddl that look like this:

```           id                               SERIAL PRIMARY KEY PRIMARY KEY,```

I'm hoping this fixes them.